### PR TITLE
chore(gitignore): add cache and checkpoint directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+
+/source_code
+/scripts/cyberid_pkg/server_kit/__pycache__
+/scripts/cyberid_pkg/learning_kit/__pycache__
+/scripts/cyberid_pkg/client_kit/__pycache__
+/scripts/cyberid_pkg/__pycache__
+/scripts/cyberid_pkg/server_kit/.ipynb_checkpoints
+/scripts/cyberid_pkg/learning_kit/.ipynb_checkpoints
+/scripts/cyberid_pkg/client_kit/.ipynb_checkpoints
+/scripts/.ipynb_checkpoints
+/scripts/cyberid_pkg/.ipynb_checkpoints
+/scripts/__pycache__


### PR DESCRIPTION
Added specific cache and checkpoint directories to `.gitignore` 
to prevent unnecessary files from being tracked in the repository.

### Ignored Files and Directories:
- Source code caches and checkpoints:
  - `/scripts/cyberid_pkg/` and its subdirectories' `__pycache__` and `.ipynb_checkpoints` folders*.
  - `/scripts/__pycache__` and `.ipynb_checkpoints`
  - `/source_code`

> (*) Including the _`client_kit`_ , _`server_kit`_ , and _`learning_kit`_ packages.

### Why this is important:
Ignoring these files prevents temporary and cache files 
from cluttering the repository, ensuring a cleaner project 
structure and easier collaboration by tracking only essential files.